### PR TITLE
fix(api-request): fix nextjs routing error and status update not gett…

### DIFF
--- a/app/dashboard/user-management/[userId]/components/change-status-dialog.tsx
+++ b/app/dashboard/user-management/[userId]/components/change-status-dialog.tsx
@@ -17,7 +17,9 @@ export const ChangeStatusDialog: React.FC<{
       options={["ACTIVE", "INACTIVE"]}
       currentValue={userStatus}
       userId={userId}
-      updateFunction={() => updateUserStatus({ userId, status: userStatus })}
+      updateFunction={({ userId, status }) =>
+        updateUserStatus({ userId, status })
+      }
       updateKey="status"
       mutateKeys={`/users/${userId}`}
       successMessage="Status updated successfully"

--- a/app/dashboard/user-management/[userId]/components/common-update-dialog.tsx
+++ b/app/dashboard/user-management/[userId]/components/common-update-dialog.tsx
@@ -34,7 +34,7 @@ export const CommonUpdateDialog: React.FC<CommonUpdateDialogProps> = ({
   triggerButton,
   updateFunction,
   updateKey,
-  mutateKeys = [`/users/${userId}`],
+  mutateKeys = `/users/${userId}`,
   successMessage,
   errorMessage,
 }) => {

--- a/lib/api/api-request.ts
+++ b/lib/api/api-request.ts
@@ -7,7 +7,7 @@ export const apiRequest = async <T>(
   method: ApiMethod,
   data?: unknown
 ): Promise<ApiResponse<T>> => {
-  const url = `/api/v1${endpoint}`;
+  const url = `${process.env.NEXT_PUBLIC_API_URL}${endpoint}`;
   const options: RequestInit = {
     method,
     headers: {
@@ -26,10 +26,13 @@ export const apiRequest = async <T>(
 
   const response = await fetch(url, options).then((res) => res.json());
   if (response.message === "Authentication required") {
-    const refresh = await fetch(`/api/v1/auth/refresh`, {
-      method: "POST",
-      credentials: "include",
-    }).then((res) => res.json());
+    const refresh = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+      {
+        method: "POST",
+        credentials: "include",
+      }
+    ).then((res) => res.json());
     if (refresh.success)
       return await fetch(url, options).then((res) => res.json());
   }

--- a/lib/api/api-server-request.ts
+++ b/lib/api/api-server-request.ts
@@ -8,7 +8,7 @@ export const apiServerRequest = async <T>(
   data?: unknown
 ): Promise<ApiResponse<T>> => {
   const cookieStore = await cookies();
-  const url = `${process.env.FRONTEND_URL}/api/v1/${endpoint}`;
+  const url = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/${endpoint}`;
 
   const cookieHeader = cookieStore
     .getAll()
@@ -50,7 +50,7 @@ export const apiServerRequest = async <T>(
 
       // Call our internal refresh API
       const refreshResponse = await fetch(
-        `http://localhost:3000/api/refresh-token`,
+        `${process.env.NEXT_PUBLIC_API_URL}/refresh-token`,
         {
           method: "POST",
           headers: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,14 +6,6 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [new URL("https://placehold.co/**")],
   },
-  async rewrites() {
-    return [
-      {
-        source: "/api/v1/:path*",
-        destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
-      },
-    ];
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request updates how API endpoints are constructed and accessed throughout the codebase to consistently use the `NEXT_PUBLIC_API_URL` environment variable. It also makes minor adjustments to dialog component props for consistency and clarity.

**API Endpoint Configuration Improvements:**

* Updated the `apiRequest` function to use `NEXT_PUBLIC_API_URL` for all API endpoint URLs instead of hardcoded paths, ensuring that API requests are environment-aware (`lib/api/api-request.ts`).
* Modified the authentication refresh endpoint in `apiRequest` to use `NEXT_PUBLIC_API_URL` as well, supporting consistent environment configuration (`lib/api/api-request.ts`).
* Changed the `apiServerRequest` function to use `NEXT_PUBLIC_API_URL` for server-side API calls, replacing the previous use of `FRONTEND_URL` (`lib/api/api-server-request.ts`).
* Updated the refresh token endpoint in `apiServerRequest` to use `NEXT_PUBLIC_API_URL`, removing the hardcoded localhost URL (`lib/api/api-server-request.ts`).
* Removed the custom `rewrites` configuration from `next.config.ts` that proxied `/api/v1` to the API URL, as endpoints are now constructed directly with the environment variable (`next.config.ts`).

**Dialog Component Prop Adjustments:**

* Updated the `updateFunction` prop in `ChangeStatusDialog` to accept an object with `userId` and `status`, improving clarity and consistency (`app/dashboard/user-management/[userId]/components/change-status-dialog.tsx`). ([app/dashboard/user-management/[userId]/components/change-status-dialog.tsxL20-R22](diffhunk://#diff-97f9a97f833c76ca23f1fdc0d838fc4c456de2d9297029650d1b9fd61f202445L20-R22))
* Changed the default value of the `mutateKeys` prop in `CommonUpdateDialog` from an array to a string for consistency with its usage (`app/dashboard/user-management/[userId]/components/common-update-dialog.tsx`). ([app/dashboard/user-management/[userId]/components/common-update-dialog.tsxL37-R37](diffhunk://#diff-5c3bc6fb71b3a4447a76b33eb29451d36f7cac9b0347a1453d8150debcd188e8L37-R37))