### PR TITLE
added dynamic url to reflect server pagination on category list page

### DIFF
--- a/app/dashboard/skill-categories/components/category-card.tsx
+++ b/app/dashboard/skill-categories/components/category-card.tsx
@@ -10,7 +10,6 @@ export const CategoryCard = ({ category: {
     description,
     imageName
 } }: { category: Cluster }) => {
-    console.log(imageName);
     return (
         <Link href="#" aria-label={`View category ${name}`} className="w-full h-full">
             <div className="rounded-b-xl shadow-lg w-full h-full">

--- a/app/dashboard/skill-categories/components/category-card.tsx
+++ b/app/dashboard/skill-categories/components/category-card.tsx
@@ -10,6 +10,7 @@ export const CategoryCard = ({ category: {
     description,
     imageName
 } }: { category: Cluster }) => {
+    console.log(imageName);
     return (
         <Link href="#" aria-label={`View category ${name}`} className="w-full h-full">
             <div className="rounded-b-xl shadow-lg w-full h-full">

--- a/app/dashboard/skill-categories/components/category-list.tsx
+++ b/app/dashboard/skill-categories/components/category-list.tsx
@@ -3,17 +3,22 @@ import { EmptyState } from "@/components/custom/empty-state";
 import { CategoryCard } from "./category-card";
 import { Loader } from "lucide-react";
 import clsx from "clsx";
-import { useState } from "react";
 import { Pagination } from "@/components/custom/pagination";
 import { paginationCalculator } from "@/lib/hooks/pagination-calculator";
 import { useClusters } from "@/lib/api/clusters";
+import { useServerSyncedPagination } from "@/lib/hooks/use-server-synced-pagination";
 
 export const CategoryList = () => {
-    const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 12 });
+    const [pagination, setPagination] = useServerSyncedPagination(undefined);
+
+    // Fetch using desired pagination (from URL)
     const { items, pageInfo, loading, error } = useClusters({
         pageIndex: pagination.pageIndex,
         pageSize: pagination.pageSize,
     });
+
+    // the hook will auto-normalize the URL on the next render
+    useServerSyncedPagination(pageInfo);
 
     const {
         currentPage,
@@ -24,7 +29,7 @@ export const CategoryList = () => {
         prevDisabled,
         nextDisabled,
     } = paginationCalculator({ items, pageInfo, pagination });
-    
+
     const hasData = items && items.length > 0;
 
     const containerClass = clsx(
@@ -65,30 +70,21 @@ export const CategoryList = () => {
                         </div>
                         <div className="flex flex-col items-center justify-between gap-2 md:flex-row">
                             <div className="flex-1 text-sm text-muted-foreground">
-                                Showing {start} to {end} { totalItems > end && <> of {totalItems}</>} resources.
+                                Showing {start} to {end} {totalItems > end && <> of {totalItems}</>} resources.
                             </div>
                             <Pagination
                                 nextDisabled={!nextDisabled}
                                 prevDisabled={!prevDisabled}
                                 handleNext={() =>
-                                    setPagination((prev) => ({
-                                        ...prev,
-                                        pageIndex: prev.pageIndex + 1,
-                                    }))
+                                    setPagination({ pageIndex: pagination.pageIndex + 1, pageSize: pagination.pageSize })
                                 }
                                 handlePrev={() =>
-                                    setPagination((prev) => ({
-                                        ...prev,
-                                        pageIndex: Math.max(prev.pageIndex - 1, 0),
-                                    }))
+                                    setPagination({ pageIndex: Math.max(pagination.pageIndex - 1, 0), pageSize: pagination.pageSize })
                                 }
                                 activePage={currentPage + 1}
                                 totalPages={totalPages}
                                 handlePaginationBtnClick={(val) =>
-                                    setPagination((prev) => ({
-                                        ...prev,
-                                        pageIndex: Math.max(val - 1, 0),
-                                    }))
+                                    setPagination({ pageIndex: Math.max(val, 0), pageSize: pagination.pageSize })
                                 }
                             />
                         </div>

--- a/lib/hooks/use-pagination-url.ts
+++ b/lib/hooks/use-pagination-url.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export interface PaginationState {
+    pageIndex: number;
+    pageSize: number;
+}
+
+interface Options {
+    defaultPageSize?: number;
+    pageParam?: string;
+    sizeParam?: string;
+}
+
+export function usePaginationUrl({
+    defaultPageSize = 12,
+    pageParam = "page",
+    sizeParam = "size",
+}: Options = {}) {
+    const searchParams = useSearchParams();
+    const pathname = usePathname();
+    const router = useRouter();
+
+    const pageIndex = Number(searchParams.get(pageParam)) >= 0 ? Number(searchParams.get(pageParam)) : 0;
+    const pageSize = Number(searchParams.get(sizeParam)) > 0 ? Number(searchParams.get(sizeParam)) : defaultPageSize;
+
+    const navigate = (state: PaginationState, preserveScroll: boolean) => {
+        const sp = new URLSearchParams(searchParams.toString());
+        sp.set(pageParam, String(Math.max(0, state.pageIndex)));
+        sp.set(sizeParam, String(Math.max(1, state.pageSize)));
+
+        router.replace(`${pathname}?${sp.toString()}`, {
+            scroll: !preserveScroll,
+        });
+    };
+
+    // For user actions (next/prev/page click), scrolls to top
+    const setPagination = (next: PaginationState, opts?: { preserveScroll?: boolean }) => {
+        navigate(next, opts?.preserveScroll ?? false);
+    };
+
+    // For server normalization, never scroll
+    const syncPagination = (next: PaginationState) => {
+        navigate(next, true);
+    };
+
+    return [{ pageIndex, pageSize }, setPagination, syncPagination] as const;
+}

--- a/lib/hooks/use-server-synced-pagination.ts
+++ b/lib/hooks/use-server-synced-pagination.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePaginationUrl, type PaginationState } from "./use-pagination-url";
+import { PageInfo } from "../types/api";
+
+interface SyncOptions {
+    defaultPageSize?: number;
+    pageParam?: string;
+    sizeParam?: string;
+}
+
+export function useServerSyncedPagination(
+    pageInfo: PageInfo | null | undefined,
+    {
+        defaultPageSize = 12,
+        pageParam,
+        sizeParam,
+    }: SyncOptions = {}
+) {
+    const [pagination, setPagination, syncPagination] = usePaginationUrl({
+        defaultPageSize,
+        pageParam,
+        sizeParam,
+    });
+
+    const lastNormalized = useRef<PaginationState | null>(null);
+
+    useEffect(() => {
+        if (!pageInfo) return;
+
+        const serverPageIndex = pageInfo.page ?? 0;
+        const serverPageSize = Math.max(1, pageInfo.size ?? pagination.pageSize);
+
+        const differs = serverPageIndex !== pagination.pageIndex || serverPageSize !== pagination.pageSize;
+
+        const already =
+            lastNormalized.current &&
+            lastNormalized.current.pageIndex === serverPageIndex &&
+            lastNormalized.current.pageSize === serverPageSize;
+
+        if (differs && !already) {
+            const newState = { pageIndex: serverPageIndex, pageSize: serverPageSize };
+            lastNormalized.current = newState;
+            syncPagination(newState);
+        }
+    }, [pageInfo, pagination.pageIndex, pagination.pageSize, syncPagination]);
+
+    return [pagination, setPagination] as const;
+}

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -45,16 +45,6 @@ export interface ListData<T> {
   pagination: PageInfo;
 }
 
-export interface AltListData<T> {
-  items: T[];
-  page: number;
-  size: number;
-  totalElements: number;
-  totalPages: number;
-  hasNext: boolean;
-  hasPrevious: boolean;
-}
-
 export interface ItemData<T> {
   item: T;
 }


### PR DESCRIPTION
# Summary

Added URL-synced pagination for the Skill Categories list. The browser URL now mirrors the server-resolved pagination (page, size). The backend remains the single source of truth, and client state normalizes to whatever the server returns.

---

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (may cause existing functionality to fail)
- [x] UI/UX improvement
- [ ] Documentation update
- [ ] Other (please specify):

---

## Implementation Details

- Introduced `usePaginationUrl` and `useServerSyncedPagination` hooks to read desired page/size from search params, fetch data using those values, and normalize the URL to the server’s authoritative page/size via `router.replace`.
- Scroll behavior: User actions (next/prev/page click) scroll page to top, while server normalization preserves scroll to avoid jarring jumps.
- Updated `CategoryList` to consume the hooks; SWR keys depend on URL-derived pagination so refetching is automatic.

---

## Screenshots / Recordings (if applicable)

<img width="2183" height="87" alt="image" src="https://github.com/user-attachments/assets/5c3f729c-1fd2-46be-ba37-5ec9f9ab8331" />

---

## Checklist

- [x] My code follows project style guidelines
- [x] I have self-reviewed my code
- [x] I have commented complex parts of the code
- [ ] Documentation has been updated (if needed)
- [x] No new warnings or errors
- [ ] Tests added or updated
- [ ] All tests pass locally
- [ ] Relevant issues linked and closed

---
