### PR TITLE
fix: fix resend verification email link

### DIFF
--- a/app/dashboard/user-management/components/user-table-menu.tsx
+++ b/app/dashboard/user-management/components/user-table-menu.tsx
@@ -16,9 +16,7 @@ export const UserTableMenu: React.FC<{
   const [isResending, startResending] = React.useTransition();
   const handleResendVerification = () =>
     startResending(async () => {
-      const response = await apiRequest(`/register/resend-invitation`, "POST", {
-        email: user.email,
-      });
+      const response = await apiRequest(`/register/resend-invitation?email=${user.email}`, "POST");
       if (!response.success) {
         toast.error(
           response.message ||


### PR DESCRIPTION
# Summary

This pull request makes a small update to how the resend invitation API is called in the `UserTableMenu` component. The change moves the user's email from the POST body to a query parameter in the request URL.