### PR TITLE
Ft/learner roadmap

### DIFF
--- a/app/dashboard/assessments/page.tsx
+++ b/app/dashboard/assessments/page.tsx
@@ -1,4 +1,5 @@
 "Use client";
+import { DashboardHeader } from "../components/header";
 import { Metrics } from "../components/metrics";
 import { TopActions } from "../components/top-actions";
 import { AssessmentList } from "./components/assessment-list";
@@ -6,6 +7,7 @@ import { AssessmentList } from "./components/assessment-list";
 export default function AssessmentsPage() {
     return (
         <>
+            <DashboardHeader title="Assessments" />
             <Metrics />
             <TopActions
                 searchPlaceholder="Search by assessments"

--- a/app/dashboard/roadmap/components/capsule-box.tsx
+++ b/app/dashboard/roadmap/components/capsule-box.tsx
@@ -49,11 +49,11 @@ export const CapsuleBox = ({
                 {isNotStarted && !isComplete && !isInProgress && (
                     <>
                         {isNextInline && isActive ? (
-                            <Link href="#">
+                            <Link href={`/dashboard/skills/${capsule.capsuleId}`}>
                                 <Button>Start</Button>
                             </Link>
                         ) : (
-                            <Link href="#" className="ml-auto text-sm text-gray-text-strong font-medium tracking-normal">
+                            <Link href={`/dashboard/skills/${capsule.capsuleId}`} className="ml-auto text-sm text-gray-text-strong font-medium tracking-normal">
                                 <GrayButton>Learn More</GrayButton>
                             </Link>
                         )}
@@ -63,14 +63,14 @@ export const CapsuleBox = ({
                 {/* Action on the right */}
                 {/* Completed → Retake */}
                 {isComplete && (
-                    <Link href="#">
+                    <Link href={`/dashboard/skills/${capsule.capsuleId}`}>
                         <GrayButton>Retake</GrayButton>
                     </Link>
                 )}
 
                 {/* In-progress → Resume */}
                 {isInProgress && (
-                    <Link href="#">
+                    <Link href={`/dashboard/skills/${capsule.capsuleId}`}>
                         <Button>Resume</Button>
                     </Link>
                 )}

--- a/app/dashboard/roadmap/components/capsule-box.tsx
+++ b/app/dashboard/roadmap/components/capsule-box.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { Separator } from "@/components/ui/separator"
+import { MyTrackCapsule } from "@/lib/types/api"
 import { Check } from "lucide-react"
 import Link from "next/link"
 
@@ -9,25 +10,20 @@ export const CapsuleBox = ({
     isActive,
     isNextInline
 }: {
-    capsule: { name: string, description: string, progress?: number },
+    capsule: MyTrackCapsule,
     isActive: boolean,
     isNextInline: boolean
 }) => {
-    const rawProgress = capsule.progress ?? undefined;
-    const isComplete = rawProgress === 100;
-    const isInProgress = rawProgress !== undefined && rawProgress > 0 && rawProgress < 100;
-    const isNotStarted = rawProgress === undefined || rawProgress === 0;
-
-    // Show progress if:
-    //  - we already have a numeric progress, OR
-    //  - this is the next inline unlocked capsule (show 0%)
-    const showProgress = rawProgress !== undefined || (isNextInline && isActive);
-    const progress = rawProgress ?? 0;
+    const progress = capsule.progressPercentage;
+    const isComplete = capsule.status === "COMPLETED";
+    const isInProgress = capsule.status === "IN_PROGRESS";
+    const isNotStarted = capsule.status === "NOT_STARTED";
+    const showProgress = capsule.status === "IN_PROGRESS" || (isNextInline && isActive);
 
     return (
         <div className="bg-sidebar w-[344px] rounded-md space-y-4 border border-brand-primary-text-weak">
             <div className="flex items-center justify-between py-1 px-2">
-                <span className="font-semibold text-sm text-gray-text-strong">{capsule.name}</span>
+                <span className="font-semibold text-sm text-gray-text-strong">{capsule.capsuleName}</span>
                 {
                     isComplete && (
                         <div className="flex items-center gap-1 text-brand-primary-text">

--- a/app/dashboard/roadmap/components/growth-track-overview.tsx
+++ b/app/dashboard/roadmap/components/growth-track-overview.tsx
@@ -1,16 +1,45 @@
 import { Progress } from "@/components/ui/progress";
+import { Loader } from "lucide-react";
+import { MyTrack } from "@/lib/types/api";
 
-export const GrowthTrackOverview = ({ data } : { data: { name: string, description: string, progress: number }}) => {
-    const { name, description, progress } = data;
+export const GrowthTrackOverview = ({
+    track,
+    loading,
+    error
+}: {
+    track: MyTrack | undefined,
+    loading: boolean,
+    error: string | null
+}) => {
+
+    if (loading || error || !track) {
+        return (
+            <section className="bg-sidebar p-4 rounded-md flex items-center justify-center text-muted-foreground">
+                {
+                    loading && (
+                        <>
+                            <Loader className="animate-spin" />
+                            <span>Loading...</span>
+                        </>
+                    )
+                }
+
+                {error && <span>{error}</span>}
+
+                {!track && <span>Failed to fetch your track. Please refresh the tab</span>}
+            </section>
+        );
+    }
+
     return (
         <section className="bg-sidebar p-4 rounded-md flex items-center justify-between">
             <div className="space-y-1">
-                <p className="font-semibold text-lg text-gray-text-strong">{name}</p>
-                <p className="text-sm text-gray-text-weak max-w-[519px] w-full">{description}</p>
+                <p className="font-semibold text-lg text-gray-text-strong">{track.trackName}</p>
+                <p className="text-sm text-gray-text-weak max-w-[519px] w-full">{track.description}</p>
             </div>
             <div className="space-y-1">
-                <p className="font-semibold text-lg text-gray-text-weak text-center">{progress}%</p>
-                <Progress value={progress} className="w-[200px] h-3 rounded-full" />
+                <p className="font-semibold text-lg text-gray-text-weak text-center">{track.progressPercentage}%</p>
+                <Progress value={track.progressPercentage} className="w-[200px] h-3 rounded-full" />
             </div>
         </section>
     );

--- a/app/dashboard/roadmap/components/growth-track-overview.tsx
+++ b/app/dashboard/roadmap/components/growth-track-overview.tsx
@@ -35,7 +35,9 @@ export const GrowthTrackOverview = ({
         <section className="bg-sidebar p-4 rounded-md flex items-center justify-between">
             <div className="space-y-1">
                 <p className="font-semibold text-lg text-gray-text-strong">{track.trackName}</p>
-                <p className="text-sm text-gray-text-weak max-w-[519px] w-full">{track.description}</p>
+                <p className="text-sm text-gray-text-weak max-w-[600px] w-full">
+                    {track.description.length > 120 ? track.description.slice(0, 120) + "..." : track.description}
+                </p>
             </div>
             <div className="space-y-1">
                 <p className="font-semibold text-lg text-gray-text-weak text-center">{track.progressPercentage}%</p>

--- a/app/dashboard/roadmap/components/roadmap-timeline.tsx
+++ b/app/dashboard/roadmap/components/roadmap-timeline.tsx
@@ -1,13 +1,16 @@
 "use client";
+
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CapsuleBox } from "./capsule-box";
 import { cn } from "@/lib/utils";
+import { useTrackCapsules } from "@/lib/api/use-track";
+import { Loader } from "lucide-react";
 
 type Capsule = { name: string, description: string, progress?: number };
-type RoadmapProps = { readonly capsules: Capsule[] };
 const CARD_HALF = 163 / 2;
 
-export function RoadmapTimeline({ capsules }: RoadmapProps) {
+export function RoadmapTimeline({ trackId }: { trackId: string }) {
+  const { capsules, loading, error } = useTrackCapsules(trackId);
   const overallHeightRef = useRef<HTMLElement | null>(null);
   const [lineHeight, setLineHeight] = useState(0);
 
@@ -15,14 +18,14 @@ export function RoadmapTimeline({ capsules }: RoadmapProps) {
   const leadingCompleted = useMemo(() => {
     let count = 0;
     for (const c of capsules) {
-      if ((c.progress ?? 0) === 100) count++;
+      if (c.progressPercentage === 100) count++;
       else break;
     }
     return count;
   }, [capsules]);
 
   // Unlocked only if all previous capsules are 100%
-  const isUnlocked = (index: number) => capsules.slice(0, index).every((c) => (c.progress ?? 0) === 100);
+  const isUnlocked = (index: number) => capsules.slice(0, index).every((c) => c.progressPercentage === 100);
 
   // first capsule that isn't fully complete
   const nextInlineIndex = useMemo(() => {
@@ -45,6 +48,23 @@ export function RoadmapTimeline({ capsules }: RoadmapProps) {
     setLineHeight(next);
   }, [capsules, leadingCompleted]);
 
+  if (loading || error) {
+    return (
+      <section className="bg-[url(/images/auth-background.jpg)] bg-cover bg-no-repeat bg-bottom rounded-md overflow-hidden bg-brand-primary-fill">
+        {
+          loading && (
+            <>
+              <Loader className="animate-spin" />
+              <span>Loading...</span>
+            </>
+          )
+        }
+
+        {error && <span>{error}</span>}
+      </section>
+    );
+  }
+
   return (
     <section className="bg-[url(/images/auth-background.jpg)] bg-cover bg-no-repeat bg-bottom rounded-md overflow-hidden bg-brand-primary-fill" >
       <div className="bg-[#00708a]/20 px-20 py-16">
@@ -60,7 +80,7 @@ export function RoadmapTimeline({ capsules }: RoadmapProps) {
           </div>
           {
             capsules.map((capsule, i) => (
-              <div className={cn("w-full flex", (i + 1) % 2 === 0 ? 'justify-end' : 'justify-start')} key={i + capsule.name}>
+              <div className={cn("w-full flex", (i + 1) % 2 === 0 ? 'justify-end' : 'justify-start')} key={capsule.capsuleId}>
                 <CapsuleBox capsule={capsule} isActive={isUnlocked(i)} isNextInline={i === nextInlineIndex} />
               </div>
             ))

--- a/app/dashboard/roadmap/components/roadmap-timeline.tsx
+++ b/app/dashboard/roadmap/components/roadmap-timeline.tsx
@@ -3,14 +3,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CapsuleBox } from "./capsule-box";
 import { cn } from "@/lib/utils";
-import { useTrackCapsules } from "@/lib/api/use-track";
-import { Loader } from "lucide-react";
-
-type Capsule = { name: string, description: string, progress?: number };
+import { MyTrackCapsule } from "@/lib/types/api";
 const CARD_HALF = 163 / 2;
 
-export function RoadmapTimeline({ trackId }: { trackId: string }) {
-  const { capsules, loading, error } = useTrackCapsules(trackId);
+export function RoadmapTimeline({ capsules }: { readonly capsules: MyTrackCapsule[] }) {
   const overallHeightRef = useRef<HTMLElement | null>(null);
   const [lineHeight, setLineHeight] = useState(0);
 
@@ -47,23 +43,6 @@ export function RoadmapTimeline({ trackId }: { trackId: string }) {
     const next = Math.max(0, Math.min(h, h * ratio) - CARD_HALF);
     setLineHeight(next);
   }, [capsules, leadingCompleted]);
-
-  if (loading || error) {
-    return (
-      <section className="bg-[url(/images/auth-background.jpg)] bg-cover bg-no-repeat bg-bottom rounded-md overflow-hidden bg-brand-primary-fill">
-        {
-          loading && (
-            <>
-              <Loader className="animate-spin" />
-              <span>Loading...</span>
-            </>
-          )
-        }
-
-        {error && <span>{error}</span>}
-      </section>
-    );
-  }
 
   return (
     <section className="bg-[url(/images/auth-background.jpg)] bg-cover bg-no-repeat bg-bottom rounded-md overflow-hidden bg-brand-primary-fill" >

--- a/app/dashboard/roadmap/page.tsx
+++ b/app/dashboard/roadmap/page.tsx
@@ -1,15 +1,18 @@
+"use client";
+
+import { useTrack } from "@/lib/api/use-track";
 import { DashboardHeader } from "../components/header";
-import { roadmap } from "@/lib/api/roadmap";
 import { GrowthTrackOverview } from "./components/growth-track-overview";
 import { RoadmapTimeline } from "./components/roadmap-timeline";
 
 export default function SkillClustersPage() {
-    const { name, description, progress, capsules } = roadmap;
+    const { track, loading, error } = useTrack();
+
     return (
         <div className="space-y-6">
             <DashboardHeader title="Roadmap" />
-            <GrowthTrackOverview data={{ name, description, progress }} />           
-            <RoadmapTimeline capsules={capsules} />
+            <GrowthTrackOverview track={track} loading={loading} error={error} />           
+            <RoadmapTimeline trackId={track?.trackId ?? ""} />
         </div>
     );
 }

--- a/app/dashboard/roadmap/page.tsx
+++ b/app/dashboard/roadmap/page.tsx
@@ -4,15 +4,33 @@ import { useTrack } from "@/lib/api/use-track";
 import { DashboardHeader } from "../components/header";
 import { GrowthTrackOverview } from "./components/growth-track-overview";
 import { RoadmapTimeline } from "./components/roadmap-timeline";
+import { Loader } from "lucide-react";
 
 export default function SkillClustersPage() {
     const { track, loading, error } = useTrack();
 
+    if (loading || error || !track) {
+        return (
+            <section className="bg-[url(/images/auth-background.jpg)] bg-cover bg-no-repeat bg-bottom rounded-md overflow-hidden bg-brand-primary-fill">
+                {
+                    loading && (
+                        <>
+                            <Loader className="animate-spin" />
+                            <span>Loading...</span>
+                        </>
+                    )
+                }
+
+                {error && <span>{error}</span>}
+            </section>
+        );
+    }
+
     return (
         <div className="space-y-6">
             <DashboardHeader title="Roadmap" />
-            <GrowthTrackOverview track={track} loading={loading} error={error} />           
-            <RoadmapTimeline trackId={track?.trackId ?? ""} />
+            <GrowthTrackOverview track={track} loading={loading} error={error} />
+            <RoadmapTimeline capsules={track.capsules} />
         </div>
     );
 }

--- a/lib/api/use-track.ts
+++ b/lib/api/use-track.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import useSWR from "swr";
+import type { MyTrack, MyTrackCapsule } from "@/lib/types/api";
+import { apiRequest } from "./api-request";
+
+const trackFetcher = (url: string) => apiRequest<MyTrack>(url, "GET");
+const capsulesFetcher = (url: string) => apiRequest<MyTrackCapsule[]>(url, "GET");
+
+export function useTrack() {
+    const { data, error, isLoading, mutate } = useSWR('/learner/my-tracks', trackFetcher);
+
+    return {
+        track: data?.data ?? undefined,
+        loading: isLoading,
+        error: error ? (error as Error).message : null,
+        revalidateRoadmap: () => mutate(),
+    };
+}
+
+export function useTrackCapsules(trackId: string) {
+    const { data, isLoading, error, mutate } = useSWR(`/learner/my-tracks/${trackId}/capsules`, capsulesFetcher);
+
+    return {
+        capsules: data?.data ?? [],
+        loading: isLoading,
+        error: error ? (error as Error).message : null,
+        revalidateCapsules: () => mutate()
+    }
+}

--- a/lib/api/use-track.ts
+++ b/lib/api/use-track.ts
@@ -1,30 +1,18 @@
 "use client";
 
 import useSWR from "swr";
-import type { MyTrack, MyTrackCapsule } from "@/lib/types/api";
+import type { MyTrack } from "@/lib/types/api";
 import { apiRequest } from "./api-request";
 
-const trackFetcher = (url: string) => apiRequest<MyTrack>(url, "GET");
-const capsulesFetcher = (url: string) => apiRequest<MyTrackCapsule[]>(url, "GET");
+const trackFetcher = (url: string) => apiRequest<MyTrack[]>(url, "GET");
 
 export function useTrack() {
     const { data, error, isLoading, mutate } = useSWR('/learner/my-tracks', trackFetcher);
 
     return {
-        track: data?.data ?? undefined,
+        track: data?.data?.at(0) ?? undefined,
         loading: isLoading,
         error: error ? (error as Error).message : null,
         revalidateRoadmap: () => mutate(),
     };
-}
-
-export function useTrackCapsules(trackId: string) {
-    const { data, isLoading, error, mutate } = useSWR(`/learner/my-tracks/${trackId}/capsules`, capsulesFetcher);
-
-    return {
-        capsules: data?.data ?? [],
-        loading: isLoading,
-        error: error ? (error as Error).message : null,
-        revalidateCapsules: () => mutate()
-    }
 }

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -70,6 +70,36 @@ export interface Track {
   }[];
 }
 
+export interface MyRoadmap {
+  learnerId: string;
+  roadmapId: string;
+  talentRoutId: string;
+  routeName: string;
+  routeDescription: string;
+  enrollmentStatus: "ACTIVE" | "COMPLETED" | "DROPPED";
+  overallProgressPercentage: number;
+  enrolledAt: string;
+}
+
+export interface MyTrack {
+  trackProgressId: string;
+  trackId: string;
+  trackName: string;
+  description: string;
+  status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+  progressPercentage: number;
+}
+
+export interface MyTrackCapsule {
+  capsuleProgressId: string;
+  capsuleId: string;
+  capsuleName: string;
+  description: string;
+  status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+  progressPercentage: number;
+  startedAt: string;
+}
+
 export interface Capsule {
   id: string;
   skillCapsuleId: string;

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -86,8 +86,11 @@ export interface MyTrack {
   trackId: string;
   trackName: string;
   description: string;
+  sequenceOrder: number;
   status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
   progressPercentage: number;
+  isUnlocked: boolean;
+  capsules: MyTrackCapsule[];
 }
 
 export interface MyTrackCapsule {
@@ -95,9 +98,10 @@ export interface MyTrackCapsule {
   capsuleId: string;
   capsuleName: string;
   description: string;
+  sequenceOrder: number;
   status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
   progressPercentage: number;
-  startedAt: string;
+  isUnlocked: boolean;
 }
 
 export interface Capsule {


### PR DESCRIPTION
# Summary

This PR introduces the roadmap page integration for a learner to visually see their current learning roadmap and choose skills to learn.

---

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (may cause existing functionality to fail)
- [x] UI/UX improvement
- [ ] Documentation update
- [ ] Other (please specify):

---

## Implementation Details

- Implemented the full Roadmap page integration for learners.
- Added a new `useTrack` hook to fetch a learner’s roadmap and skill capsule data using SWR for efficient data fetching, caching, and revalidation.

---

## Screenshots / Recordings (if applicable)

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/3fe8c4b8-9458-4c62-a162-43a342151703" />

---

## Checklist

- [x] My code follows project style guidelines
- [x] I have self-reviewed my code
- [x] I have commented complex parts of the code
- [ ] Documentation has been updated (if needed)
- [x] No new warnings or errors
- [ ] Tests added or updated
- [ ] All tests pass locally
- [ ] Relevant issues linked and closed

---
