### PR TITLE
fix: admin not being able to open lessons, and learner not being able to open lessons that are completed

### DIFF
--- a/app/dashboard/skills/[skillId]/components/single-lesson-list-card.tsx
+++ b/app/dashboard/skills/[skillId]/components/single-lesson-list-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/api/skills";
 import { useProgressMetadata } from "@/lib/hooks/use-progress-metadata";
 import { SKillStatus } from "@/lib/types/api";
+import { useCheckRole } from "@/lib/hooks/use-check-role";
 
 type LessonListCardProps = {
   data: LessonProps & { skillId: string };
@@ -25,6 +26,7 @@ export const SingleLessonListCard = ({
   const router = useRouter();
   const isFirst = index === 0;
   const isLast = index === total - 1;
+  const { isAdmin } = useCheckRole();
   const { capsuleLessons } = useGetRoadmapCapsuleLessons(data.skillId);
   const { roadmap, track } = useProgressMetadata(data.skillId);
   const lessonToOpen = capsuleLessons?.data?.find(
@@ -35,16 +37,12 @@ export const SingleLessonListCard = ({
       router.push(
         `/dashboard/skills/${data.skillId}/contents?activeLesson=${data.id}&moodleId=${data.moodlePageId}`
       );
+    if (isAdmin || lessonToOpen?.completed) return navigate();
     if (!isSkillActive) {
       toast.error("Please start the skill to access its lessons.");
       return;
     }
-    if (
-      lessonToOpen?.completed ||
-      lessonToOpen?.status === SKillStatus.IN_PROGRESS
-    ) {
-      return navigate();
-    }
+    if (lessonToOpen?.status === SKillStatus.IN_PROGRESS) return navigate();
 
     const res = handleSKillProgress({
       capsuleId: data.skillId,

--- a/app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsx
+++ b/app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsx
@@ -19,7 +19,7 @@ import { cn } from "@/lib/utils";
 export const MainSkillContents = () => {
   const searchParams = useSearchParams();
   const params = useParams();
-  const { isAdmin } = useCheckRole();
+  const { isAdmin, isLearner } = useCheckRole();
   const lessonId = searchParams.get("activeLesson") as string;
   const moodleId = searchParams.get("moodleId") as string;
   const { skillId } = params as { skillId: string };
@@ -112,17 +112,19 @@ export const MainSkillContents = () => {
       <article className="w-full flex justify-between items-center">
         <h2 className="justify-start text-lg font-semibold leading-relaxed text-start text-gray-text-strong/90">
           {lesson?.name || "N/A"}{" "}
-          <span
-            className={cn(
-              "text-xs p-1 px-2 rounded-lg border  uppercase ms-5",
-              lessonStatus === SKillStatus.COMPLETED &&
-                "bg-green-fill text-green-text border-green-text",
-              lessonStatus === SKillStatus.IN_PROGRESS &&
-                "bg-amber-fill text-amber-text border-amber-text"
-            )}
-          >
-            {lessonStatusLabel}
-          </span>
+          {isLearner && (
+            <span
+              className={cn(
+                "text-xs p-1 px-2 rounded-lg border  uppercase ms-5",
+                lessonStatus === SKillStatus.COMPLETED &&
+                  "bg-green-fill text-green-text border-green-text",
+                lessonStatus === SKillStatus.IN_PROGRESS &&
+                  "bg-amber-fill text-amber-text border-amber-text"
+              )}
+            >
+              {lessonStatusLabel}
+            </span>
+          )}
         </h2>
         {isAdmin && (
           <Button variant={"ghost"} className="px-4 bg-gray-stroke-weak/60">
@@ -140,22 +142,24 @@ export const MainSkillContents = () => {
           )
         )}
       </div>
-      <div className="flex justify-end gap-4 ">
-        <Button
-          variant={"outline"}
-          onClick={handleUpdateLessonStatus}
-          disabled={matchingLesson?.status === SKillStatus.COMPLETED}
-        >
-          {matchingLesson?.status === SKillStatus.COMPLETED ? (
-            "Completed"
-          ) : (
-            <>
-              <CheckCircle />
-              Mark as complete
-            </>
-          )}
-        </Button>
-      </div>
+      {isLearner && (
+        <div className="flex justify-end gap-4 ">
+          <Button
+            variant={"outline"}
+            onClick={handleUpdateLessonStatus}
+            disabled={matchingLesson?.status === SKillStatus.COMPLETED}
+          >
+            {matchingLesson?.status === SKillStatus.COMPLETED ? (
+              "Completed"
+            ) : (
+              <>
+                <CheckCircle />
+                Mark as complete
+              </>
+            )}
+          </Button>
+        </div>
+      )}
     </section>
   );
 };

--- a/app/dashboard/skills/[skillId]/contents/components/tab-skill-contents.tsx
+++ b/app/dashboard/skills/[skillId]/contents/components/tab-skill-contents.tsx
@@ -6,6 +6,7 @@ import {
   useFetchSingleSkill,
   useGetRoadmapCapsuleLessons,
 } from "@/lib/api/skills";
+import { useCheckRole } from "@/lib/hooks/use-check-role";
 import { useProgressMetadata } from "@/lib/hooks/use-progress-metadata";
 import { SKillStatus } from "@/lib/types/api";
 import { cn } from "@/lib/utils";
@@ -16,6 +17,7 @@ import { toast } from "sonner";
 
 export const TabSkillContents = () => {
   const router = useRouter();
+  const { isAdmin } = useCheckRole();
   const searchParams = useSearchParams();
   const { skillId } = useParams();
   const { skill, isFetchingSkill, fetchSkillError } = useFetchSingleSkill(
@@ -26,13 +28,14 @@ export const TabSkillContents = () => {
     useGetRoadmapCapsuleLessons(skillId as string);
 
   const handleActivateSkill = (key: string, moodlePageId: string) => {
-    const lessonToOpen = capsuleLessons?.data?.find((l) => l.atomId === key);
     const navigate = () => {
       const params = new URLSearchParams(Array.from(searchParams.entries()));
       params.set("activeLesson", key);
       params.set("moodleId", moodlePageId);
       router.push(`?${params.toString()}`, { scroll: true });
     };
+    if (isAdmin) return navigate();
+    const lessonToOpen = capsuleLessons?.data?.find((l) => l.atomId === key);
     if (
       lessonToOpen?.completed ||
       lessonToOpen?.status === SKillStatus.IN_PROGRESS

--- a/app/dashboard/skills/[skillId]/page.tsx
+++ b/app/dashboard/skills/[skillId]/page.tsx
@@ -43,8 +43,7 @@ function SingleSkillPage() {
   }, [fetchedSkill]);
   const handleStartSkill = () => {
     const firstLessonEndpoint = `/dashboard/skills/${skillId}/contents?activeLesson=${lessons?.[0].id}&moodleId=${lessons?.[0].moodlePageId}`;
-
-    if (status === SKillStatus.IN_PROGRESS) {
+    if (status === SKillStatus.IN_PROGRESS || status === SKillStatus.COMPLETED) {
       router.push(firstLessonEndpoint);
       return;
     }

--- a/app/dashboard/skills/components/learner-dropdown.tsx
+++ b/app/dashboard/skills/components/learner-dropdown.tsx
@@ -12,7 +12,10 @@ export const LearnerDropdown = ({ skillId }: { skillId: string }) => {
   const { status, isNextInLine, startLabel, isDisabled } =
     useProgressMetadata(skillId);
   const handleStartSkill = () => {
-    if (status === SKillStatus.IN_PROGRESS) {
+    if (
+      status === SKillStatus.IN_PROGRESS ||
+      status === SKillStatus.COMPLETED
+    ) {
       router.push(`/dashboard/skills/${skillId}`);
       return;
     }


### PR DESCRIPTION
# Summary
This pull request introduces role-based access improvements and UI adjustments for skill and lesson navigation in the dashboard. The main changes ensure that admin and learner roles have tailored access to lesson navigation and actions, and that completed skills are handled consistently in navigation logic.

**Role-based navigation and UI updates:**

* Added `useCheckRole` hook usage to determine user roles (`isAdmin`, `isLearner`) in `single-lesson-list-card.tsx`, `main-skill-contents.tsx`, and `tab-skill-contents.tsx`, enabling role-specific logic and UI rendering. ([app/dashboard/skills/[skillId]/components/single-lesson-list-card.tsxR12](diffhunk://#diff-548f3732a0fca74291ade7c00402b3b2c62bad2ec39df7834878eafff9e25bdfR12), [app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsxL22-R22](diffhunk://#diff-d5fee2866c93333d75d70e066b41dc19d13a88db705136505e61a5042031f9adL22-R22), [app/dashboard/skills/[skillId]/contents/components/tab-skill-contents.tsxR9](diffhunk://#diff-3b9f4d96cfadd8943ba95c57b58cfedf94d7288c796b3af5856e1dbea663d12eR9))
* Updated lesson navigation logic in `single-lesson-list-card.tsx` and `tab-skill-contents.tsx` to allow admins to access lessons regardless of completion status, while learners are restricted based on lesson progress. ([app/dashboard/skills/[skillId]/components/single-lesson-list-card.tsxR29](diffhunk://#diff-548f3732a0fca74291ade7c00402b3b2c62bad2ec39df7834878eafff9e25bdfR29), [app/dashboard/skills/[skillId]/components/single-lesson-list-card.tsxR40-R45](diffhunk://#diff-548f3732a0fca74291ade7c00402b3b2c62bad2ec39df7834878eafff9e25bdfR40-R45), [app/dashboard/skills/[skillId]/contents/components/tab-skill-contents.tsxR20](diffhunk://#diff-3b9f4d96cfadd8943ba95c57b58cfedf94d7288c796b3af5856e1dbea663d12eR20), [app/dashboard/skills/[skillId]/contents/components/tab-skill-contents.tsxL29-R38](diffhunk://#diff-3b9f4d96cfadd8943ba95c57b58cfedf94d7288c796b3af5856e1dbea663d12eL29-R38))

**UI adjustments for learners and admins:**

* Conditionally rendered lesson status labels and action buttons for learners in `main-skill-contents.tsx`, ensuring learners see relevant status and actions. ([app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsxR115](diffhunk://#diff-d5fee2866c93333d75d70e066b41dc19d13a88db705136505e61a5042031f9adR115), [app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsxR127](diffhunk://#diff-d5fee2866c93333d75d70e066b41dc19d13a88db705136505e61a5042031f9adR127), [app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsxR145](diffhunk://#diff-d5fee2866c93333d75d70e066b41dc19d13a88db705136505e61a5042031f9adR145), [app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsxR162](diffhunk://#diff-d5fee2866c93333d75d70e066b41dc19d13a88db705136505e61a5042031f9adR162))
* Ensured admin-specific UI elements are only shown to admins in `main-skill-contents.tsx`. ([app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsxL22-R22](diffhunk://#diff-d5fee2866c93333d75d70e066b41dc19d13a88db705136505e61a5042031f9adL22-R22), [app/dashboard/skills/[skillId]/contents/components/main-skill-contents.tsxR115](diffhunk://#diff-d5fee2866c93333d75d70e066b41dc19d13a88db705136505e61a5042031f9adR115))

**Navigation logic consistency:**

* Modified skill start logic in `page.tsx` and `learner-dropdown.tsx` to treat both "in progress" and "completed" statuses the same, redirecting users appropriately. ([app/dashboard/skills/[skillId]/page.tsxL46-R46](diffhunk://#diff-ee8b71055cca8dacede0dc2c771e980ecadf3c2f580fb57b4599d9c7a0def456L46-R46), [app/dashboard/skills/components/learner-dropdown.tsxL15-R18](diffhunk://#diff-65343d9d4b190ea18e450661574313ed847bbfcb1d3e38bf2cc8963955dd7283L15-R18))
