### PR TITLE
feat: create assesment form, and handle assement submission

### DIFF
--- a/app/dashboard/assessments/components/assessment-card.tsx
+++ b/app/dashboard/assessments/components/assessment-card.tsx
@@ -37,7 +37,9 @@ export const AssessmentCard = ({
                 <span>Created:</span>
                 <span>{assessment.createdAt}</span>
             </div>
-            <div className="flex items-center gap-1">
+            {/* This are commmented out for now, because the assigned field is not available in the API response */}
+            
+            {/* <div className="flex items-center gap-1">
                 <span className="text-sm text-gray-text-weak">Assigned:</span>
                 <div className="flex -space-x-2">
                     {
@@ -53,7 +55,9 @@ export const AssessmentCard = ({
                         ))
                     }
                 </div>
-            </div>
+                
+            </div> */}
+            
             <p className="text-sm text-gray-text-weak">{assessment.description}</p>
             <div className="flex flex-wrap gap-1">
                 {

--- a/app/dashboard/assessments/components/create-assesment-form.tsx
+++ b/app/dashboard/assessments/components/create-assesment-form.tsx
@@ -156,7 +156,7 @@ export const CreateAssesmentForm = () => {
             {form.formState.isSubmitting && (
               <Loader className=" animate-spin" />
             )}
-            Send Invite
+            Create Assessment
           </Button>
         </div>
       </form>

--- a/app/dashboard/assessments/components/create-assesment-form.tsx
+++ b/app/dashboard/assessments/components/create-assesment-form.tsx
@@ -1,0 +1,165 @@
+"use client";
+import React from "react";
+import { Form, FormField } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { CustomInput } from "@/components/custom/custom-input";
+import { CustomSelect } from "@/components/custom/custom-select";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  assessmentSchema,
+  AssessmentSchemaProps,
+} from "@/lib/schemas/assesments";
+import { CustomTextarea } from "@/components/custom/custom-text-area";
+import { SheetClose } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Loader } from "lucide-react";
+import { useFetchSkills } from "@/lib/api/skills";
+import { apiRequest } from "@/lib/api/api-request";
+import { toast } from "sonner";
+
+export const CreateAssesmentForm = () => {
+  const closeRef = React.useRef<HTMLButtonElement>(null);
+  const { skills, isFetchingSkills } = useFetchSkills();
+  const form = useForm({
+    resolver: zodResolver(assessmentSchema),
+    defaultValues: {
+      instructions: "Answer all questions carefully",
+    },
+  });
+  const onSubmit = async (data: AssessmentSchemaProps) => {
+    const fetchedSkills = skills?.data?.items || [];
+    const selectedSkillId = fetchedSkills.find(
+      (skill) => skill.name === data.skillName
+    )?.id;
+
+    const res = await apiRequest("/assessment", "POST", {
+      ...data,
+      skillCapsuleId: selectedSkillId,
+    });
+    if (!res.success) toast.error(res.message || "Failed to create assessment");
+    else {
+      toast.success("Assessment created successfully");
+      closeRef.current?.click();
+    }
+  };
+  if (isFetchingSkills) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full mt-4 min-h-[400px]">
+        <Loader className="animate-spin" size={30} />
+      </div>
+    );
+  }
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          name="assessmentName"
+          control={form.control}
+          render={({ field }) => (
+            <CustomInput label="Assessment name *" {...field} />
+          )}
+        />
+        <FormField
+          name="skillName"
+          control={form.control}
+          render={({ field }) => (
+            <CustomSelect
+              label="Skill"
+              onChange={field.onChange}
+              value={field.value}
+              selectValues={
+                skills?.data?.items.map((skill) => skill.name) || []
+              }
+            />
+          )}
+        />
+        <FormField
+          name="assessmentType"
+          control={form.control}
+          render={({ field }) => (
+            <CustomSelect
+              label="Type"
+              onChange={field.onChange}
+              value={field.value}
+              selectValues={["QUIZ", "ASSIGNMENT", "PROJECT"]}
+            />
+          )}
+        />
+
+        <FormField
+          name="passingScore"
+          control={form.control}
+          render={({ field: { onChange, value, ...field } }) => (
+            <CustomInput
+              label="Passing Score (%)"
+              type="number"
+              inputMode="numeric"
+              value={value?.toString() || ""}
+              onChange={(e) => {
+                const value = e.target.value;
+                onChange(value === "" ? 0 : parseFloat(value) || 0);
+              }}
+              {...field}
+            />
+          )}
+        />
+
+        <FormField
+          name="timeLimitMinutes"
+          control={form.control}
+          render={({ field: { onChange, value, ...field } }) => (
+            <CustomInput
+              label="Time Limit (Minutes)"
+              type="number"
+              inputMode="numeric"
+              value={value?.toString() || ""}
+              onChange={(e) => {
+                const value = e.target.value;
+                onChange(value === "" ? 0 : parseFloat(value) || 0);
+              }}
+              {...field}
+            />
+          )}
+        />
+
+        <FormField
+          name="maxAttempts"
+          control={form.control}
+          render={({ field: { onChange, value, ...field } }) => (
+            <CustomInput
+              label="Max Attempts"
+              type="number"
+              inputMode="numeric"
+              value={value?.toString() || ""}
+              onChange={(e) => {
+                const value = e.target.value;
+                onChange(value === "" ? 0 : parseFloat(value) || 0);
+              }}
+              {...field}
+            />
+          )}
+        />
+        <FormField
+          name="instructions"
+          control={form.control}
+          render={({ field }) => (
+            <CustomTextarea label="Instructions" {...field} />
+          )}
+        />
+        <div className="flex justify-end space-x-3 mb-5">
+          <SheetClose asChild>
+            <Button variant={"outline"} ref={closeRef}>
+              Cancel
+            </Button>
+          </SheetClose>
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting && (
+              <Loader className=" animate-spin" />
+            )}
+            Send Invite
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/app/dashboard/assessments/components/question.tsx
+++ b/app/dashboard/assessments/components/question.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useEffect, useState } from "react";
+function extractQuestionData(rawHtml: string) {
+  const html = rawHtml.replace(/^"|"$/g, "").replace(/\\"/g, '"');
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+
+  const questionContainer = doc.querySelector(".que");
+  const questionType = questionContainer?.classList?.[1] || "unknown";
+  const qubaid = questionContainer?.getAttribute("id")?.replace("q", "") || "";
+
+  const questionText = doc.querySelector(".qtext p")?.textContent.trim() || "";
+
+  const answers = Array.from(doc.querySelectorAll(".answer input")).map(
+    (input) => {
+      const label = doc
+        .querySelector(`label[for="${input.id}"]`)
+        ?.textContent.trim();
+      return {
+        value: (input as HTMLInputElement).value,
+        label: label || input.nextSibling?.textContent?.trim() || "",
+      };
+    }
+  );
+
+  return { questionText, answers, questionType, qubaid };
+}
+
+const QUESTION_TYPES = [
+  { type: "truefalse", inputType: "radio" },
+  { type: "multichoice", inputType: "checkbox" },
+  // future types can easily be added here 👇
+  // { type: "shortanswer", inputType: "text" },
+];
+
+export default function Question({ html }: { readonly html: string }) {
+  const [data, setData] = useState<{
+    questionText: string;
+    answers: { value: string; label: string }[];
+    questionType: string;
+    qubaid: string;
+  }>({
+    questionText: "",
+    answers: [],
+    questionType: "",
+    qubaid: "",
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setData(extractQuestionData(html));
+    }
+  }, [html]);
+
+  if (!data.questionText) return null;
+
+  const inputType =
+    QUESTION_TYPES.find((q) => data.questionType.includes(q.type))?.inputType ||
+    "radio";
+
+  return (
+    <div
+      className="p-4 border rounded-xl shadow-sm bg-white mb-4"
+      data-qubaid={data.qubaid}
+      data-type={data.questionType}
+    >
+      <h4 className="font-semibold mb-3">{data.questionText}</h4>
+      <div className="space-y-2">
+        {data.answers.map((a, i) => (
+          <label
+            key={"label-" + i}
+            className="flex items-center gap-2 hover:bg-gray-50 rounded-md p-2 transition"
+          >
+            <input type={inputType} name={`q-${data.qubaid}`} value={a.value} />
+            <span>{a.label}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/assessments/page.tsx
+++ b/app/dashboard/assessments/page.tsx
@@ -1,21 +1,38 @@
 "Use client";
+import { Button } from "@/components/ui/button";
 import { DashboardHeader } from "../components/header";
 import { Metrics } from "../components/metrics";
+import { SheetWrapper } from "../components/sheet-wrapper";
 import { TopActions } from "../components/top-actions";
 import { AssessmentList } from "./components/assessment-list";
+import { CreateAssesmentForm } from "./components/create-assesment-form";
+import { Plus } from "lucide-react";
 
 export default function AssessmentsPage() {
-    return (
-        <>
-            <DashboardHeader title="Assessments" />
-            <Metrics />
-            <TopActions
-                searchPlaceholder="Search by assessments"
-                isRoleFilterable={false}
-                isStatusFilterable={false}
-                isAssessmentFilterable={true}
-            />
-            <AssessmentList />
-        </>
-    );
+  return (
+    <>
+      <DashboardHeader title="Assessments" />
+      <Metrics />
+      <TopActions
+        searchPlaceholder="Search by assessments"
+        isRoleFilterable={false}
+        isStatusFilterable={false}
+        isAssessmentFilterable={true}
+        rightActions={
+          <SheetWrapper
+            trigger={
+              <Button>
+                <Plus /> Create Assesment
+              </Button>
+            }
+            headerTitle="Create assesment"
+            headerDescription="Submit essential data to create an assesment on moodle"
+          >
+            <CreateAssesmentForm />
+          </SheetWrapper>
+        }
+      />
+      <AssessmentList />
+    </>
+  );
 }

--- a/lib/schemas/assesments.ts
+++ b/lib/schemas/assesments.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+export const assessmentSchema = z.object({
+  assessmentName: z
+    .string("Assessment name is required")
+    .regex(
+      /^[A-Za-z0-9 ]+$/,
+      "Assessment name cannot contain special characters"
+    )
+    .min(3, "Assessment name must be at least 3 characters"),
+  skillName: z
+    .string("Skill name is required")
+    .min(2, "Skill name must be at least 2 characters")
+    .max(50, "Skill name must be at most 50 characters"),
+  assessmentType: z.string("Assesment is required"),
+  maxAttempts: z
+    .number("Max attempts must be a number")
+    .min(1, "Max attempts must be at least 1")
+    .max(1000, "Max attempts must not exceed 1000"),
+  passingScore: z
+    .number("Passing score must be a number")
+    .min(1, "Passing score must be at least 1")
+    .max(1000, "Passing score must not exceed 1000"),
+  timeLimitMinutes: z
+    .number("Time limit must be a number")
+    .min(1, "Time limit must be at least 1 minute")
+    .max(1000, "Time limit must not exceed 1000 minutes"),
+  instructions: z
+    .string()
+    .max(500, "Instructions must be at most 500 characters"),
+});
+
+export type AssessmentSchemaProps = z.infer<typeof assessmentSchema>;


### PR DESCRIPTION
# Summary

This pull request adds a new feature for creating assessments in the dashboard, including a new form component, validation schema, and integration into the assessments page. The changes introduce a modal form for assessment creation, with robust validation and improved user experience.

**New Assessment Creation Feature:**

* Added the `CreateAssesmentForm` component, which provides a form for users to create new assessments, including fields for assessment name, skill, type, passing score, time limit, max attempts, and instructions. The form uses `react-hook-form` and integrates with the API to submit data.
* Implemented the `assessmentSchema` in `lib/schemas/assesments.ts` using Zod for validation, ensuring all form fields are validated for correct format and constraints.

**Integration with Assessments Page UI:**

* Updated the assessments page to include a "Create Assesment" button that opens the new form in a modal (`SheetWrapper`), enhancing the workflow for adding assessments. [[1]](diffhunk://#diff-a65299daf6421d59332bdb69290a5664a099b1871457fc38efd78ade5091c640R2-R9) [[2]](diffhunk://#diff-a65299daf6421d59332bdb69290a5664a099b1871457fc38efd78ade5091c640R21-R33)
* Connected the form to the skills API for dynamic skill selection and provided user feedback via loading states and toast notifications.
