### PR TITLE
chore: implemented the nested-like structure to sidebar

### DIFF
--- a/components/custom/app-sidebar.tsx
+++ b/components/custom/app-sidebar.tsx
@@ -32,7 +32,6 @@ import {
   LogOut,
   FileText,
   FileCheck,
-  ChevronUp,
 } from "lucide-react";
 import { CustomPopover } from "./custom-popover";
 import { Button } from "../ui/button";
@@ -265,7 +264,7 @@ export function AppSidebar() {
                         {item.items.length > 0 && (
                           <CollapsibleContent>
                             <SidebarMenu className="pl-8">
-                              {item.items.map((subItem) => (
+                              {item.items.map((subItem, idx) => (
                                 <SidebarMenuItem key={subItem.title}>
                                   <SidebarMenuButton
                                     asChild
@@ -283,7 +282,13 @@ export function AppSidebar() {
                                       href={subItem.url}
                                       aria-label={`${subItem.title} page`}
                                     >
-                                      <span>{subItem.title}</span>
+                                      <span
+                                        style={{
+                                          paddingInlineStart: `${idx * 16}px`,
+                                        }}
+                                      >
+                                        {subItem.title}
+                                      </span>
                                     </Link>
                                   </SidebarMenuButton>
                                 </SidebarMenuItem>


### PR DESCRIPTION
# Summary
This pull request introduces a minor UI enhancement to the sidebar menu in `components/custom/app-sidebar.tsx`. The main change is the addition of indentation for submenu items based on their index, improving visual hierarchy and readability.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (may cause existing functionality to fail)
- [x] UI/UX improvement
- [ ] Documentation update
- [ ] Other (please specify):

---

## Implementation Details
Sidebar submenu UI improvements:

* Added inline padding to submenu item titles in the sidebar, with indentation increasing by 16px per item index for better visual organization.
* Updated the submenu mapping to include the item index (`idx`) for calculating indentation.

Other cleanup:
* Removed unused `ChevronUp` import from `lucide-react`.


## Screenshots / Recordings (if applicable)
<img width="555" height="864" alt="image" src="https://github.com/user-attachments/assets/5d6404d1-2d7c-4cd3-ada5-532e938139a4" />
---
